### PR TITLE
fix #28 : 학습시 batchsize 이상하게 학습하는 부분 수정 close #28

### DIFF
--- a/Baseline_Code_V4/trainers/MatrixBasedTrainer.py
+++ b/Baseline_Code_V4/trainers/MatrixBasedTrainer.py
@@ -20,7 +20,7 @@ class MatrixBasedTrainer(Trainer):
 
         self.dataloader = DataLoader(
             self.preprocessed_dataset,
-            batch_size=args.batch_size,
+            batch_size=margs.batch_size,
             shuffle=True,
             pin_memory=True,
             num_workers=margs.num_workers,


### PR DESCRIPTION
DataLoader에 초기화 값이 None 이면 batchsize가 1로 알아서 돌아가는 거
같네요 오류가 안나고 이렇게 돌아가는게 당황스럽긴 합니다.